### PR TITLE
Add note about pin number in docblock

### DIFF
--- a/openag/cli/firmware/__init__.py
+++ b/openag/cli/firmware/__init__.py
@@ -270,8 +270,9 @@ def run_module(
     ctx, arguments, project_dir, board, **kwargs
 ):
     """
-    Run a single instance of this module. [ARGUMENTS] specify the signal
-    pin numbers used on the Arduino for this module (required).
+    Run a single instance of this module. [ARGUMENTS] specifies a list of
+    implementation-specific arguments to the module (for example, configuring
+    Arduino pin numbers for the module).
 
     Example:
 

--- a/openag/cli/firmware/__init__.py
+++ b/openag/cli/firmware/__init__.py
@@ -269,7 +269,15 @@ def run(
 def run_module(
     ctx, arguments, project_dir, board, **kwargs
 ):
-    """ Run a single instance of this module """
+    """
+    Run a single instance of this module. [ARGUMENTS] specify the signal
+    pin numbers used on the Arduino for this module (required).
+
+    Example:
+
+    \b
+    openag firmware run_module -t upload 4
+    """
     # Read the module config
     here = os.path.abspath(project_dir)
     module_json_path = os.path.join(here, "module.json")


### PR DESCRIPTION
The previous help text was a bit ambiguous. Add note about arguments being used to specify module pin numbers.