### PR TITLE
Unify module json format with fixture format

### DIFF
--- a/openag/cli/firmware/__init__.py
+++ b/openag/cli/firmware/__init__.py
@@ -166,8 +166,9 @@ def run(
                 continue
             click.echo("Parsing firmware module \"{}\"".format(_id))
             firmware.append(FirmwareModule(db[_id]))
-    else:
-        raise click.ClickException("No modules specified for the project")
+
+    if len(firmware) == 0:
+        click.echo("Warning: no modules specified for the project")
 
     module_types = index_by_id(firmware_types)
     modules = index_by_id(firmware)

--- a/openag/cli/firmware/__init__.py
+++ b/openag/cli/firmware/__init__.py
@@ -149,7 +149,7 @@ def run(
                 doc = json.load(f)
                 if not doc.get("_id"):
                     # Patch in id if id isn't present
-                    doc["_id"] = parent_dirname(module_file_path)
+                    doc["_id"] = parent_dirname(config_path)
                 firmware_types.append(FirmwareModuleType(doc))
 
     # Get the list of modules

--- a/openag/models.py
+++ b/openag/models.py
@@ -5,6 +5,7 @@ __all__ = [
 
 from .categories import SENSORS, ACTUATORS, CALIBRATION
 from voluptuous import Schema, Required, Any, Extra, Optional, REMOVE_EXTRA
+from openag.utils import safe_cpp_var
 
 Environment = Schema({
     "name": Any(str, unicode),
@@ -246,6 +247,7 @@ GitRepo = Schema({
 })
 
 FirmwareModuleType = Schema({
+    Required("_id"): safe_cpp_var,
     "repository": Any(PioRepo, GitRepo),
     Required("header_file"): Any(str, unicode),
     Required("class_name"): Any(str, unicode),
@@ -313,6 +315,7 @@ for information on how to write firmware modules.
 """
 
 FirmwareModule = Schema({
+    Required("_id"): safe_cpp_var,
     Required("type"): Any(str, unicode),
     "environment": Any(str, unicode),
     "arguments": [object],

--- a/openag/utils.py
+++ b/openag/utils.py
@@ -1,8 +1,7 @@
 from openag.categories import SENSORS, ACTUATORS
+import os
+import re
 from urlparse import urlparse
-from os import path
-
-__all__ = ["synthesize_firmware_module_info"]
 
 def synthesize_firmware_module_info(modules, module_types):
     """
@@ -78,6 +77,11 @@ def synthesize_firmware_module_info(modules, module_types):
         res[mod_id] = mod_info
     return res
 
+def index_by_id(docs):
+    """Index a list of docs using `_id` field.
+    Returns a dictionary keyed by _id."""
+    return {doc["_id"]: doc for doc in docs}
+
 def dedupe_by(things, key=None):
     """
     Given an iterator of things and an optional key generation function, return
@@ -89,16 +93,51 @@ def dedupe_by(things, key=None):
     index = {key(thing): thing for thing in things}
     return index.values()
 
+def parent_dirname(file_path):
+    return os.path.basename(os.path.dirname(file_path))
+
 def make_dir_name_from_url(url):
     """This function attempts to emulate something like Git's "humanish"
     directory naming for clone. It's probably not a perfect facimile,
     but it's close."""
     url_path = urlparse(url).path
-    head, tail = path.split(url_path)
+    head, tail = os.path.split(url_path)
     # If tail happens to be empty as in case `/foo/`, use foo.
     # If we are looking at a valid but ugly path such as
     # `/foo/.git`, use the "foo" not the ".git".
     if len(tail) is 0 or tail[0] is ".":
-        head, tail = path.split(head)
-    dir_name, ext = path.splitext(tail)
+        head, tail = os.path.split(head)
+    dir_name, ext = os.path.splitext(tail)
     return dir_name
+
+# C++ keywords list
+CPP_KEYWORDS = [
+    "alignas", "alignof", "and", "and_eq", "asm", "atomic_cancel",
+    "atomic_commit", "atomic_noexcept", "auto", "bitand", "bitor", "bool",
+    "break", "case", "catch", "char", "char16_t", "char32_t", "class",
+    "compl", "concept", "const", "constexpr", "const_cast", "continue",
+    "decltype", "default", "delete", "do", "double", "dynamic_cast",
+    "else", "enum", "explicit", "export", "extern", "false", "float",
+    "for", "friend", "goto", "if", "inline", "int", "long", "mutable",
+    "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator",
+    "or", "or_eq", "private", "protected", "public", "register",
+    "reinterpret_cast", "requires", "return short", "signed", "sizeof",
+    "static", "static_assert", "static_cast", "struct", "switch",
+    "synchronized", "template", "this", "thread_local", "throw", "true",
+    "try", "typedef", "typeid", "typename", "union", "unsigned", "using",
+    "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"
+]
+
+def safe_cpp_var(s):
+    """
+    Given a string representing a variable, return a new string that is safe
+    for C++ codegen. If string is already safe, will leave it alone.
+    """
+    s = str(s)
+    # Remove non-word, non-space characters
+    s = re.sub(r"[^\w\s]", '', s)
+    # Replace spaces with _
+    s = re.sub(r"\s+", '_', s)
+    # Prefix with underscore if what is left is a reserved word
+    s = "_" + s if s in CPP_KEYWORDS or s[0].isdigit() else s
+    return s

--- a/tests/test_cli/test_codegen.py
+++ b/tests/test_cli/test_codegen.py
@@ -4,6 +4,7 @@ import tempfile
 from click import ClickException
 from click.testing import CliRunner
 
+from openag.db_names import FIRMWARE_MODULE
 from openag.cli.firmware import init, run, run_module
 
 EXAMPLE_HEADER = """
@@ -38,6 +39,7 @@ bool Module::get_output(std_msgs::Float32 &msg) {
 void Module::set_input(std_msgs::Float32 msg) { }
 """
 EXAMPLE_JSON = json.dumps({
+    "_id": "module",
     "class_name": "Module",
     "header_file": "module.h",
     "inputs": {
@@ -142,9 +144,12 @@ def test_run_single_module():
             f.write(EXAMPLE_JSON)
         with open(os.path.join(here, "modules.json"), "w+") as f:
             json.dump({
-                "module": {
-                    "type": "module"
-                }
+                FIRMWARE_MODULE: [
+                    {
+                        "_id": "module",
+                        "type": "module"
+                    }
+                ]
             }, f)
 
         res = runner.invoke(run, ["-f", "modules.json"])
@@ -179,8 +184,16 @@ def test_run_multiple_modules():
             f.write(EXAMPLE_JSON)
         with open(os.path.join(here, "modules.json"), "w+") as f:
             json.dump({
-                "module_a": {"type": "module"},
-                "module_b": {"type": "module"}
+                FIRMWARE_MODULE: [
+                    {
+                        "_id": "module_a",
+                        "type": "module"
+                    },
+                    {
+                        "_id": "module_b",
+                        "type": "module"
+                    }
+                ]
             }, f)
 
         res = runner.invoke(run, ["-f", "modules.json"])
@@ -248,7 +261,14 @@ bool Module::get_output(std_msgs::UInt8MultiArray &msg) {
                 }
             }, f)
         with open(os.path.join(here, "modules.json"), "w+") as f:
-            json.dump({"module": {"type": "module"}}, f)
+            json.dump({
+                FIRMWARE_MODULE: [
+                    {
+                        "_id": "module",
+                        "type": "module"
+                    }
+                ]
+            }, f)
 
         res = runner.invoke(run, ["-f", "modules.json", "-p", "csv"])
         assert isinstance(res.exception, RuntimeError), repr(res.exception)
@@ -319,12 +339,16 @@ def test_run_invalid_module_ids():
             f.write(EXAMPLE_JSON)
         with open(os.path.join(here, "modules.json"), "w+") as f:
             json.dump({
-                "for": {
-                    "type": "module"
-                },
-                "123": {
-                    "type": "module"
-                }
+                FIRMWARE_MODULE: [
+                    {
+                        "_id": "for",
+                        "type": "module"
+                    },
+                    {
+                        "_id": "123",
+                        "type": "module"
+                    }
+                ]
             }, f)
 
         res = runner.invoke(run, ["-f", "modules.json"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,55 @@
+from openag.utils import (
+    index_by_id, dedupe_by, make_dir_name_from_url, safe_cpp_var,
+    parent_dirname
+)
+
+EXAMPLE_DOCS = [
+    {
+        "_id": "foo",
+        "type": "a"
+    },
+    {
+        "_id": "foo",
+        "type": "b"
+    },
+    {
+        "_id": "bar",
+        "type": "c"
+    }
+]
+
+def get_id(doc):
+    return doc["_id"]
+
+def test_index_by_id():
+    index = index_by_id(EXAMPLE_DOCS)
+    # Assert multiple items with same key are de-duped
+    assert len(index.keys()) == 2
+    # Assert last item wins
+    assert index["foo"]["type"] == "b"
+
+def test_dedupe_by():
+    docs = dedupe_by(EXAMPLE_DOCS, get_id)
+    assert len(docs) == 2
+
+def test_make_dir_name_from_url():
+    url_a = "http://github.com/OpenAgInitiative/openag_am2315.git"
+    a = make_dir_name_from_url(url_a)
+    assert a == "openag_am2315", a
+
+    url_b = "http://foo.xyz:8000/openag_am2315/.git"
+    b = make_dir_name_from_url(url_b)
+    assert b == "openag_am2315", b
+
+    url_c = "http://foo.xyz/bar/"
+    c = make_dir_name_from_url(url_c)
+    assert c == "bar", c
+
+def test_safe_cpp_var():
+    safe_var = safe_cpp_var("for")
+    assert safe_var == "my_for"
+
+def test_parent_dirname():
+    assert parent_dirname("foo/bar.git") == "foo"
+    assert parent_dirname("foo/bar/baz") == "bar"
+    assert parent_dirname("foo/bar/baz/") == "baz"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,7 +47,7 @@ def test_make_dir_name_from_url():
 
 def test_safe_cpp_var():
     safe_var = safe_cpp_var("for")
-    assert safe_var == "my_for"
+    assert safe_var == "_for"
 
 def test_parent_dirname():
     assert parent_dirname("foo/bar.git") == "foo"


### PR DESCRIPTION
This PR changes the module file behavior so that module files use the same format as fixtures. This has some useful advantages:

- A full configuration of modules and types can be flashed to device while doing development work, without changing the database configuration.
- Multiple firmware configurations can be easily tested in development, simply by having multiple modules files. Again, you don't have to change the database or worry about the merged results of loading multiple fixture files.
- We reduce the number of JSON formats that we need to document and distribute.
- Fixtures can be used directly for testing.

This PR also makes the C++ var escaping and module.json naming more robust.