### PR TITLE
Status codes instead of status messages

### DIFF
--- a/docs/firmware_modules.rst
+++ b/docs/firmware_modules.rst
@@ -25,7 +25,12 @@ working as desired). The superclass also defines a :cpp:member:`status_msg`
 attribute which is a :cpp:class:`String` that the firmware module should use to
 describe the status of the module. This is generally an empty string when the
 status level is "ok" and an error message when the status level is "warn" or
-"error".
+"error". Finally, the superclass defines a :cpp:member:`status_code` attribute
+which is a :spp:class:`uint8_t` value that the firmware module should use to
+describe the status of the module. This serves the same purpose as the 
+:cpp:member:`status_msg` field. The `module.json` file (described in more
+detail below) should contain a dictionary explaining the meaning of all valid
+:cpp:member:`status_code` values for the module.
 
 In addition to these standard functions and attributes (which are all defined
 in the header file for the :cpp:class:`Module` class), the module must define a

--- a/openag/cli/firmware/base.py
+++ b/openag/cli/firmware/base.py
@@ -322,8 +322,7 @@ class CodeGen(Plugin):
         return [
             GitRepo({
                 "type": "git",
-                "url": "https://github.com/OpenAgInitiative/rosserial_arduino_libs.git",
-                "branch": "diagnostics"
+                "url": "https://github.com/OpenAgInitiative/rosserial_arduino_libs.git"
             })
         ]
 

--- a/openag/cli/firmware/base.py
+++ b/openag/cli/firmware/base.py
@@ -1,7 +1,6 @@
 __all__ = ["Plugin", "CodeGen"]
 
 import itertools
-from openag.models import PioRepo
 from ...utils import dedupe_by, make_dir_name_from_url
 
 def FlowManager(start_string, end_string):
@@ -317,14 +316,6 @@ class CodeGen(Plugin):
                         plugin.read_module_status(mod_name, f)
                 for plugin in self.plugins:
                     plugin.end_read_module_status(f)
-
-    def pio_dependencies(self):
-        return [
-            PioRepo({
-                "type": "pio",
-                "id": 345
-            })
-        ]
 
     def header_files(self):
         res = set()

--- a/openag/cli/firmware/base.py
+++ b/openag/cli/firmware/base.py
@@ -1,6 +1,7 @@
 __all__ = ["Plugin", "CodeGen"]
 
 import itertools
+from openag.models import GitRepo
 from ...utils import dedupe_by, make_dir_name_from_url
 
 def FlowManager(start_string, end_string):
@@ -316,6 +317,15 @@ class CodeGen(Plugin):
                         plugin.read_module_status(mod_name, f)
                 for plugin in self.plugins:
                     plugin.end_read_module_status(f)
+
+    def git_dependencies(self):
+        return [
+            GitRepo({
+                "type": "git",
+                "url": "https://github.com/OpenAgInitiative/rosserial_arduino_libs.git",
+                "branch": "diagnostics"
+            })
+        ]
 
     def header_files(self):
         res = set()

--- a/openag/cli/firmware/plugins/ros.py
+++ b/openag/cli/firmware/plugins/ros.py
@@ -1,16 +1,6 @@
-from openag.models import GitRepo
 from ..base import Plugin
 
 class ROSCommPlugin(Plugin):
-    def git_dependencies(self):
-        return [
-            GitRepo({
-                "type": "git",
-                "url": "https://github.com/OpenAgInitiative/rosserial_arduino_libs.git",
-                "branch": "diagnostics"
-            })
-        ]
-
     def header_files(self):
         return set([
             "ros.h", "openag_brain/DiagnosticStatus.h",

--- a/openag/models.py
+++ b/openag/models.py
@@ -255,7 +255,8 @@ FirmwareModuleType = Schema({
     "arguments": [FirmwareArgument],
     "inputs": {Extra: FirmwareInput},
     "outputs": {Extra: FirmwareOutput},
-    "dependencies": [Any(PioRepo, GitRepo)]
+    "dependencies": [Any(PioRepo, GitRepo)],
+    "codes": {int: Any(str, unicode)}
 }, extra=REMOVE_EXTRA)
 FirmwareModuleType.__doc__ = """
 A :class:`~openag.models.FirmwareModuleType` represents a firmware library for
@@ -312,6 +313,11 @@ for information on how to write firmware modules.
     (dict) A list of libraries on which this module depends. In particular, it
     should be a list of dictionaries with the same structure as is required by
     the "repository" field.
+
+.. py:attribute:: codes
+
+    (dict) A dictionary mapping status codes (as 8-bit integers) for this
+    module to strings describing the relevant status.
 """
 
 FirmwareModule = Schema({

--- a/openag/models.py
+++ b/openag/models.py
@@ -256,7 +256,7 @@ FirmwareModuleType = Schema({
     "inputs": {Extra: FirmwareInput},
     "outputs": {Extra: FirmwareOutput},
     "dependencies": [Any(PioRepo, GitRepo)],
-    "codes": {int: Any(str, unicode)}
+    "status_codes": {Extra: Any(str, unicode)}
 }, extra=REMOVE_EXTRA)
 FirmwareModuleType.__doc__ = """
 A :class:`~openag.models.FirmwareModuleType` represents a firmware library for
@@ -314,7 +314,7 @@ for information on how to write firmware modules.
     should be a list of dictionaries with the same structure as is required by
     the "repository" field.
 
-.. py:attribute:: codes
+.. py:attribute:: status_codes
 
     (dict) A dictionary mapping status codes (as 8-bit integers) for this
     module to strings describing the relevant status.

--- a/openag/utils.py
+++ b/openag/utils.py
@@ -26,6 +26,8 @@ def synthesize_firmware_module_info(modules, module_types):
         mod_info["class_name"] = mod_type["class_name"]
         if "dependencies" in mod_type:
             mod_info["dependencies"] = mod_type["dependencies"]
+        if "status_codes" in mod_type:
+            mod_info["status_codes"] = mod_type["status_codes"]
         # Update the arguments
         args = list(mod_info.get("arguments", []))
         type_args = list(mod_type.get("arguments", []))

--- a/tests/test_cli/test_codegen.py
+++ b/tests/test_cli/test_codegen.py
@@ -22,6 +22,7 @@ class Module {
     void set_input(std_msgs::Float32 msg);
     uint8_t status_level;
     String status_msg;
+    uint8_t status_code;
 };
 
 #endif """
@@ -38,7 +39,7 @@ bool Module::get_output(std_msgs::Float32 &msg) {
 
 void Module::set_input(std_msgs::Float32 msg) { }
 """
-EXAMPLE_JSON = json.dumps({
+EXAMPLE_MODULE_JSON = json.dumps({
     "_id": "module",
     "class_name": "Module",
     "header_file": "module.h",
@@ -52,6 +53,12 @@ EXAMPLE_JSON = json.dumps({
             "type": "std_msgs/Float32",
         }
     }
+})
+
+EXAMPLE_LIBRARY_JSON = json.dumps({
+    "name": "module",
+    "frameworks": "arduino",
+    "platforms": "*"
 })
 
 def test_run_no_modules():
@@ -113,7 +120,10 @@ def test_run_module():
             f.write(EXAMPLE_SOURCE)
         # Write module.json file
         with open("module.json", "w+") as f:
-            f.write(EXAMPLE_JSON)
+            f.write(EXAMPLE_MODULE_JSON)
+        # Write library.json file
+        with open("library.json", "w+") as f:
+            f.write(EXAMPLE_LIBRARY_JSON)
 
         # Initialize the project
         res = runner.invoke(init)
@@ -141,7 +151,9 @@ def test_run_single_module():
         with open(os.path.join(module_folder, "module.cpp"), "w+") as f:
             f.write(EXAMPLE_SOURCE)
         with open(os.path.join(module_folder, "module.json"), "w+") as f:
-            f.write(EXAMPLE_JSON)
+            f.write(EXAMPLE_MODULE_JSON)
+        with open(os.path.join(module_folder, "library.json"), "w+") as f:
+            f.write(EXAMPLE_LIBRARY_JSON)
         with open(os.path.join(here, "modules.json"), "w+") as f:
             json.dump({
                 FIRMWARE_MODULE: [
@@ -181,7 +193,9 @@ def test_run_multiple_modules():
         with open(os.path.join(module_folder, "module.cpp"), "w+") as f:
             f.write(EXAMPLE_SOURCE)
         with open(os.path.join(module_folder, "module.json"), "w+") as f:
-            f.write(EXAMPLE_JSON)
+            f.write(EXAMPLE_MODULE_JSON)
+        with open(os.path.join(module_folder, "library.json"), "w+") as f:
+            f.write(EXAMPLE_LIBRARY_JSON)
         with open(os.path.join(here, "modules.json"), "w+") as f:
             json.dump({
                 FIRMWARE_MODULE: [
@@ -317,6 +331,9 @@ void MyModule::update() { }
                 ]
             }, f)
 
+        with open("library.json", "w+") as f:
+            f.write(EXAMPLE_LIBRARY_JSON)
+
         res = runner.invoke(run_module, ["-p", "csv"])
         assert res.exit_code == 0, repr(res.exception) or res.output
 
@@ -336,7 +353,9 @@ def test_run_invalid_module_ids():
         with open(os.path.join(module_folder, "module.cpp"), "w+") as f:
             f.write(EXAMPLE_SOURCE)
         with open(os.path.join(module_folder, "module.json"), "w+") as f:
-            f.write(EXAMPLE_JSON)
+            f.write(EXAMPLE_MODULE_JSON)
+        with open(os.path.join(module_folder, "library.json"), "w+") as f:
+            f.write(EXAMPLE_LIBRARY_JSON)
         with open(os.path.join(here, "modules.json"), "w+") as f:
             json.dump({
                 FIRMWARE_MODULE: [
@@ -400,6 +419,9 @@ void MyModule::update() {
                     }
                 ]
             }, f)
+
+        with open("library.json", "w+") as f:
+            f.write(EXAMPLE_LIBRARY_JSON)
 
         res = runner.invoke(run_module)
         assert res.exit_code == 0, repr(res.exception)


### PR DESCRIPTION
Fix for #16. ROS plugin now uses `openag_brain/DiagnosticStatus` messages instead of `diagnostics/DiagnosticStatus` messages for efficiency. This PR also adds documentation for the `status_code` field in both firmware module code and `firmware_module_type` records.