### PR TITLE
Document need for library.json file in firmware modules

### DIFF
--- a/docs/firmware_modules.rst
+++ b/docs/firmware_modules.rst
@@ -57,6 +57,12 @@ In addition the module should define a `module.json` file containing all of the
 metadata about the firmware module. In particular, it should be an instance of
 the :py:class:`openag.models.FirmwareModuleType` schema encoded as JSON.
 
+The system uses PlatformIO to compile Arduino sketches, so modules must also
+define a `library.json` file meeting the PlatformIO specifications. To work
+with our system, this file need only contain the fields `name` and `framework`.
+The `name` field should be the name of the module, and the `framework` field
+should have the value `arduino`.
+
 I/O Categories
 --------------
 


### PR DESCRIPTION
With the release of PlatformIO 3.0 a few months ago, `pio run` now actually checks that every library it uses at compile time declares itself compatible with the framework being used to build the project. This means that our firmware modules have to contain valid PlatformIO configuration files saying that they are compatible with the Arduino framework. This PR adds documentation of this new requirement