### PR TITLE
Firmware module stuff

### DIFF
--- a/openag/_design/firmware_module_type/validate_doc_update.js
+++ b/openag/_design/firmware_module_type/validate_doc_update.js
@@ -2,12 +2,14 @@ function(newDoc, oldDoc, userCtx, secObj) {
   if (newDoc._deleted) {
     return;
   }
-  var required_fields = ['header_file', 'class_name', 'description'];
-  var field;
-  for (var i in required_fields) {
-    field = required_fields[i];
-    if (!newDoc.hasOwnProperty(field)) {
-      throw({forbidden: "FirmwareModuleType instances are required to have a " + field + " field"});
+  if (!newDoc.hasOwnProperty("repository")) {
+    var required_fields = ['header_file', 'class_name', 'description'];
+    var field;
+    for (var i in required_fields) {
+      field = required_fields[i];
+      if (!newDoc.hasOwnProperty(field)) {
+        throw({forbidden: "FirmwareModuleType instances are required to have a " + field + " field"});
+      }
     }
   }
   var required_argument_fields = ["name", "type"];

--- a/openag/cli/db/__init__.py
+++ b/openag/cli/db/__init__.py
@@ -191,6 +191,5 @@ def update_module_types():
         new_obj = update_record(FirmwareModuleType(obj), temp_folder)
         new_obj["_rev"] = obj["_rev"]
         if new_obj != obj:
-            print "Updating object"
             db[_id] = new_obj
     rmtree(temp_folder)

--- a/openag/cli/db/__init__.py
+++ b/openag/cli/db/__init__.py
@@ -2,11 +2,17 @@ import os
 import json
 import time
 import click
+import subprocess
+from os import path
+from shutil import rmtree
+from tempfile import mkdtemp
 from couchdb.http import urljoin
 
 from openag import _design
 from openag.couch import Server, ResourceNotFound
-from openag.db_names import all_dbs
+from openag.utils import make_dir_name_from_url
+from openag.models import FirmwareModuleType
+from openag.db_names import all_dbs, FIRMWARE_MODULE_TYPE
 from .. import utils
 from ..config import config
 from .db_config import generate_config
@@ -147,3 +153,44 @@ def load_fixture(fixture_file):
                     if item == old_item:
                         continue
                 db[item_id] = item
+
+def update_record(obj, temp_folder):
+    if not "repository" in obj:
+        return obj
+    repo = obj["repository"]
+    if repo["type"] != "git":
+        return obj
+    url = repo["url"]
+    branch = repo.get("branch", "master")
+    dir_name = make_dir_name_from_url(url)
+    subprocess.call(
+        ["git", "clone", "-b", branch, url, dir_name], cwd=temp_folder
+    )
+    config_path = path.join(temp_folder, path.join(dir_name, "module.json"))
+    with open(config_path) as f:
+        info = json.load(f)
+    new_obj = dict(obj)
+    new_obj.update(info)
+    return new_obj
+
+@db.command()
+def update_module_types():
+    """
+    Download the repositories for all of the firmware_module_type records and
+    update them using the `module.json` files from the repositories themselves.
+    Currently only works for git repositories.
+    """
+    local_url = config["local_server"]["url"]
+    server = Server(local_url)
+    db = server[FIRMWARE_MODULE_TYPE]
+    temp_folder = mkdtemp()
+    for _id in db:
+        if _id.startswith("_"):
+            continue
+        obj = db[_id]
+        new_obj = update_record(FirmwareModuleType(obj), temp_folder)
+        new_obj["_rev"] = obj["_rev"]
+        if new_obj != obj:
+            print "Updating object"
+            db[_id] = new_obj
+    rmtree(temp_folder)

--- a/openag/models.py
+++ b/openag/models.py
@@ -249,8 +249,8 @@ GitRepo = Schema({
 FirmwareModuleType = Schema({
     Required("_id"): safe_cpp_var,
     "repository": Any(PioRepo, GitRepo),
-    Required("header_file"): Any(str, unicode),
-    Required("class_name"): Any(str, unicode),
+    "header_file": Any(str, unicode),
+    "class_name": Any(str, unicode),
     "description": Any(str, unicode),
     "arguments": [FirmwareArgument],
     "inputs": {Extra: FirmwareInput},


### PR DESCRIPTION
This is a response to #12. In theory, `firmware_module_type` records could be inserted into the database with just an ID and a repository, and the system should be able to figure out the rest by cloning the repository and reading the `module.json` file. This is an initial implementation of this idea. It loosens the requirement on `firmware_module_type` records so that if the `repository` field is present, no other fields are required. It also creates a new command `openag db update_module_types` that reads in all of the `firmware_module_type` records, clones their git repos, and updates the records using the information in the `module.json` file. I will submit a PR to `openag_brain` later that simplifies the default fixture file and uses this new command to fill in the missing information.

cc @gordonbrander 