### PR TITLE
modified required recipe fields

### DIFF
--- a/openag/_design/recipes/validate_doc_update.js
+++ b/openag/_design/recipes/validate_doc_update.js
@@ -2,7 +2,7 @@ function(newDoc, oldDoc, userCtx, secObj) {
   if (newDoc._deleted) {
     return;
   }
-  var required_fields = ['format', 'operations'];
+  var required_fields = ['format'];
   var field;
   for (var i in required_fields) {
     field = required_fields[i];


### PR DESCRIPTION
The new recipe format uses the term "phases" instead of operations. Recommend removing this restriction on the couchdb recipe document database.

See [openag_brain PR266](https://github.com/OpenAgInitiative/openag_brain/pull/266) for details.